### PR TITLE
updated module name AV

### DIFF
--- a/src/Material/Icons/AV.elm
+++ b/src/Material/Icons/AV.elm
@@ -1,4 +1,4 @@
-module Material.Icons.Av where
+module Material.Icons.AV where
 
 {-|
 

--- a/src/Material/Icons/Av.elm
+++ b/src/Material/Icons/Av.elm
@@ -1,4 +1,4 @@
-module Material.Icons.AV where
+module Material.Icons.Av where
 
 {-|
 


### PR DESCRIPTION
I was getting an error in elm:

```
The module name is messed up for elm-stuff/packages/TheSeamau5/elm-material-icons/1.0.0/src/Material/Icons/AV.elm
    According to the file's name it should be Material.Icons.AV
    According to the source code it should be Material.Icons.Av
Which is it?
```

This seemed to fix it.
